### PR TITLE
Update atom-like-brackets-editor.less

### DIFF
--- a/styles/atom-like-brackets-editor.less
+++ b/styles/atom-like-brackets-editor.less
@@ -21,16 +21,17 @@ atom-text-editor {
   // background-color: hsl(180, 24%, 12%);
 }
 
-// To style other content in the text editor's shadow DOM, use the ::shadow expression
-atom-text-editor::shadow .cursor {
+// Starting from Atom v1.13.0, the contents of atom-text-editor elements are no longer encapsulated within a shadow DOM boundary
+
+atom-text-editor.editor .cursor {
   border-color: #BFEE90;
 }
 
-atom-text-editor::shadow .line.cursor-line {
+atom-text-editor.editor .line.cursor-line {
     background: rgba(255, 255, 255, 0.1);
 }
 
-atom-text-editor::shadow  .bracket-matcher .region {
+atom-text-editor.editor .bracket-matcher .region {
   // border: 1px solid rgba(222, 149, 54, 0.6);
   border-radius: 5px;
   background-color: rgba(255, 0, 255, 0.6);


### PR DESCRIPTION
Starting from Atom v1.13.0, the contents of atom-text-editor elements are no longer encapsulated within a shadow DOM boundary. This means you should stop using :host and ::shadow pseudo-selectors, and prepend all your syntax selectors with syntax--. To prevent breakage with existing style sheets, Atom will automatically upgrade the following selectors:

atom-text-editor::shadow .cursor => atom-text-editor.editor .cursor
atom-text-editor::shadow .line.cursor-line => atom-text-editor.editor .line.cursor-line
atom-text-editor::shadow .bracket-matcher .region => atom-text-editor.editor .bracket-matcher .region